### PR TITLE
adding functions for 2p alignment

### DIFF
--- a/fimpy/alignment/plane.py
+++ b/fimpy/alignment/plane.py
@@ -1,0 +1,54 @@
+import numpy as np
+from scipy.ndimage.interpolation import shift
+from skimage.feature import register_translation
+from fimpy.alignment.volume import sobel_stack
+
+
+def align_single_planes_sobel(
+    stack,
+    fft_ref=None,
+    prefilter_sigma=3.3,
+    upsample_factor=10,
+    maxshift=15,
+    offset=[0, 0],
+):
+    """ Aligns planes in time, z dimension is space
+
+    :param stack: the input video, dimensions [t, z, y, x]
+    :param reference : the reference image, if not present, align to the mean
+        of all, or take_first frames
+    :param take_first: the number of frames to take to generate the reference
+    :param algorithm: ecc for translation ecc-euc for translation and rotation
+        or ecc-af for affine transforms or thunder
+    :return: aligned video
+    """
+    offset = np.array(offset)
+
+    shifts = np.empty((stack.shape[0], stack.shape[1], 2))
+    shifted = np.empty((stack.shape[0],) + fft_ref.shape, stack.dtype)
+
+    for i in range(stack.shape[1]):
+        to_fix = sobel_stack(stack[:, i, :, :], prefilter_sigma)
+        l = []
+        for t in range(to_fix.shape[0]):
+            shifts[t, i, :] = (
+                register_translation(
+                    np.fft.fftn(to_fix[t]),
+                    fft_ref[i],
+                    space="fourier",
+                    upsample_factor=upsample_factor,
+                    return_error=False,
+                )
+                + offset
+            )
+
+            if np.any(np.abs(shifts[t, i, :] - offset) > maxshift):
+                l.append(t)
+                shifted[t, i, :, :] = 0  # to_fix[t, :, :]
+            else:
+                shifted[t, i, :, :] = shift(
+                    stack[t, i, :, :], -shifts[t, i, :], order=1
+                )
+        if len(l) > 0:
+            print("got problems in frames {}".format(l))
+    return shifted, shifts

--- a/fimpy/alignment/plane.py
+++ b/fimpy/alignment/plane.py
@@ -2,6 +2,7 @@ import numpy as np
 from scipy.ndimage.interpolation import shift
 from skimage.feature import register_translation
 from fimpy.alignment.volume import sobel_stack
+from skimage.registration import phase_cross_correlation
 
 
 def align_single_planes_sobel(
@@ -32,7 +33,7 @@ def align_single_planes_sobel(
         l = []
         for t in range(to_fix.shape[0]):
             shifts[t, i, :] = (
-                register_translation(
+                phase_cross_correlation(
                     np.fft.fftn(to_fix[t]),
                     fft_ref[i],
                     space="fourier",

--- a/fimpy/pipeline/alignment.py
+++ b/fimpy/pipeline/alignment.py
@@ -8,6 +8,8 @@ from fimpy.alignment.volume import (
     shift_stack,
     sobel_stack,
 )
+from skimage.feature import register_translation
+from fimpy.alignment.plane import align_single_planes_sobel
 
 
 def align_volumes_with_filtering(
@@ -154,3 +156,116 @@ def apply_shifts(dataset, output_dir=None, block_size=120, n_jobs=10, verbose=Fa
         for i_block, (_, new_block) in enumerate(new_dataset.slices(as_tuples=True))
     )
     return new_dataset.finalize()
+
+
+def align_2p_volume(
+    dataset,
+    output_dir=None,
+    reference=None,
+    n_frames_ref=10,
+    across_planes=None,
+    prefilter_sigma=3.3,
+    upsample_factor=10,
+    max_shift=15,
+    n_jobs=20,
+    verbose=True,
+):
+    """ Function for complete alignment of two-photon, planar acquired stack
+
+    :param dataset: input H5Dataset
+    :param output_dir: optional, output destination directory, subdirectory aligned will appear
+    :param reference: optional, reference to align to
+    :param n_frames_ref: number of frames to take as reference mean, if reference is being calculated
+    :param across_planes: bool, True by default if reference is not provided, whether to align across planes
+    :param prefilter_sigma: feature size to filter for better alignment. if < 0 no filtering will take place
+    :param upsample_factor: granularity of subpixel shift
+    :param max_shift: maximum shift allowed
+    :param n_jobs: number of parallel jobs
+    :return: reference to align dataset
+    """
+
+    # prepare the destination
+    new_dataset = EmptySplitDataset(
+        root=output_dir or dataset.root.parent,
+        name="aligned",
+        shape_full=dataset.shape,
+        shape_block=(dataset.shape_block[0], 1) + dataset.shape_block[2:],
+    )
+
+    if verbose:
+        print("Calculating filtered reference")
+    if reference is None:
+        t_mid = dataset.shape[0] // 2
+        reference = dataset[t_mid : t_mid + n_frames_ref, :, :, :].mean(0)
+        if across_planes is None:
+            across_planes = False
+    else:
+        if across_planes is None:
+            across_planes = True
+
+    sob_ref = sobel_stack(reference, prefilter_sigma)
+
+    n_planes = reference.shape[0]
+    shifts_planes = np.zeros((n_planes, 2))
+
+    centre_plane = int(n_planes // 2)
+
+    if across_planes:
+        if verbose:
+            print("Registering across planes...")
+        # Find between-planes shifts
+        for i in range(centre_plane, reference.shape[0] - 1):
+            s, _, _ = register_translation(
+                reference[i, :, :], reference[i + 1, :, :], 10
+            )
+            shifts_planes[i + 1, :] = shifts_planes[i, :] + s
+        for i in range(centre_plane, 0, -1):
+            s, _, _ = register_translation(
+                reference[i, :, :], reference[i - 1, :, :], 10
+            )
+            shifts_planes[i - 1, :] = shifts_planes[i, :] + s
+
+    fl.save(dataset.root.parent / "shifts.h5", shifts_planes)
+
+    if verbose:
+        print("Aligning individual planes...")
+    Parallel(n_jobs=n_jobs)(
+        delayed(_align_and_shift)(
+            dataset,
+            new_block,
+            sob_ref[i_block : i_block + 1, :, :],
+            str(new_dataset.root / new_dataset.files[i_block]),
+            shifts_planes[i_block, :],
+            prefilter_sigma,
+            upsample_factor,
+            max_shift,
+        )
+        for i_block, (_, new_block) in enumerate(new_dataset.slices(as_tuples=True))
+    )
+
+    return new_dataset.finalize()
+
+
+def _align_and_shift(
+    dataset,
+    block,
+    ref,
+    out_file,
+    shift_plane,
+    prefilter_sigma,
+    upsample_factor,
+    max_shift,
+):
+    stack = dataset[Blocks.block_to_slices(block)]
+    shifted, shifts = align_single_planes_sobel(
+        stack,
+        np.fft.fftn(ref),
+        prefilter_sigma=prefilter_sigma,
+        upsample_factor=upsample_factor,
+        maxshift=max_shift,
+        offset=-shift_plane,
+    )
+    fl.save(out_file, dict(stack_4D=shifted, shifts=shifts), compression="blosc")
+
+    print("Saved {}...".format(out_file))
+

--- a/fimpy/pipeline/alignment.py
+++ b/fimpy/pipeline/alignment.py
@@ -215,12 +215,12 @@ def align_2p_volume(
             print("Registering across planes...")
         # Find between-planes shifts
         for i in range(centre_plane, reference.shape[0] - 1):
-            s, _, _ = register_translation(
+            s, _, _ = phase_cross_correlation(
                 reference[i, :, :], reference[i + 1, :, :], 10
             )
             shifts_planes[i + 1, :] = shifts_planes[i, :] + s
         for i in range(centre_plane, 0, -1):
-            s, _, _ = register_translation(
+            s, _, _ = phase_cross_correlation(
                 reference[i, :, :], reference[i - 1, :, :], 10
             )
             shifts_planes[i - 1, :] = shifts_planes[i, :] + s

--- a/fimpy/pipeline/alignment.py
+++ b/fimpy/pipeline/alignment.py
@@ -8,7 +8,7 @@ from fimpy.alignment.volume import (
     shift_stack,
     sobel_stack,
 )
-from skimage.feature import register_translation
+from skimage.registration import phase_cross_correlation
 from fimpy.alignment.plane import align_single_planes_sobel
 
 


### PR DESCRIPTION
Added the old 2p alignment function to fimpy:
1) The align_2p_volume and _align_and_shift functions were added to fimpy/pipline/alignment. 
2) I made small bug fixes so now it fits the new fimpy and split_dataset modules. 
3) These functions now use the register_translation from skimage and not from fimpy. 
4) I added a new file named _plane_ to fimpy/alignment and copied there the align_single_planes_sobel function. 